### PR TITLE
Keep Android envvars

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -72,7 +72,8 @@ common_SRC_FILES:= \
 	tun.c tun.h \
 	win32.h win32.c \
 	cryptoapi.h cryptoapi.c \
-	missing.c
+	missing.c \
+	android.c android.h
 
 #common_CFLAGS += -DNO_WINDOWS_BRAINDEATH 
 

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ am_openvpn_OBJECTS = base64.$(OBJEXT) buffer.$(OBJEXT) \
 	session_id.$(OBJEXT) shaper.$(OBJEXT) sig.$(OBJEXT) \
 	socket.$(OBJEXT) socks.$(OBJEXT) ssl.$(OBJEXT) \
 	status.$(OBJEXT) thread.$(OBJEXT) tun.$(OBJEXT) \
-	win32.$(OBJEXT) cryptoapi.$(OBJEXT)
+	win32.$(OBJEXT) cryptoapi.$(OBJEXT) android.$(OBJEXT)
 openvpn_OBJECTS = $(am_openvpn_OBJECTS)
 openvpn_LDADD = $(LDADD)
 openvpn_DEPENDENCIES = 
@@ -368,7 +368,8 @@ openvpn_SOURCES = \
 	thread.c thread.h \
 	tun.c tun.h \
 	win32.h win32.c \
-	cryptoapi.h cryptoapi.c
+	cryptoapi.h cryptoapi.c \
+	android.c android.h
 
 #nodist_html_DATA = openvpn.8.html
 dist_man_MANS = openvpn.8

--- a/Makefile.am
+++ b/Makefile.am
@@ -138,7 +138,8 @@ openvpn_SOURCES = \
 	thread.c thread.h \
 	tun.c tun.h \
 	win32.h win32.c \
-	cryptoapi.h cryptoapi.c
+	cryptoapi.h cryptoapi.c \
+	android.c android.h
 
 
 dist-hook:

--- a/Makefile.in
+++ b/Makefile.in
@@ -102,7 +102,7 @@ am_openvpn_OBJECTS = base64.$(OBJEXT) buffer.$(OBJEXT) \
 	session_id.$(OBJEXT) shaper.$(OBJEXT) sig.$(OBJEXT) \
 	socket.$(OBJEXT) socks.$(OBJEXT) ssl.$(OBJEXT) \
 	status.$(OBJEXT) thread.$(OBJEXT) tun.$(OBJEXT) \
-	win32.$(OBJEXT) cryptoapi.$(OBJEXT)
+	win32.$(OBJEXT) cryptoapi.$(OBJEXT) android.$(OBJEXT)
 openvpn_OBJECTS = $(am_openvpn_OBJECTS)
 openvpn_LDADD = $(LDADD)
 openvpn_DEPENDENCIES = @LIBOBJS@
@@ -368,7 +368,8 @@ openvpn_SOURCES = \
 	thread.c thread.h \
 	tun.c tun.h \
 	win32.h win32.c \
-	cryptoapi.h cryptoapi.c
+	cryptoapi.h cryptoapi.c \
+	android.c android.h
 
 @WIN32_TRUE@nodist_html_DATA = openvpn.8.html
 @WIN32_FALSE@dist_man_MANS = openvpn.8

--- a/android.c
+++ b/android.c
@@ -1,0 +1,36 @@
+/*
+ * Android specific stuff
+ */
+#include "syshead.h"
+
+#ifdef ANDROID
+
+#include "misc.h"
+#include "android.h"
+
+void
+env_set_add_android (struct env_set *es)
+{
+  const char *and_env_name[] = { "ANDROID_ASSETS",
+                                 "ANDROID_BOOTLOGO",
+                                 "ANDROID_CACHE",
+                                 "ANDROID_DATA",
+                                 "ANDROID_PROPERTY_WORKSPACE",
+                                 "ANDROID_ROOT",
+                                 "BOOTCLASSPATH",
+                                 "EXTERNAL_STORAGE",
+                                 "SD_EXT_DIRECTORY"
+                               };
+  const int and_env_count = sizeof(and_env_name) / sizeof(*and_env_name);
+  char *and_env_value[and_env_count];
+
+  int i;
+  for (i = 0; i < and_env_count; i++) {
+    char *name = and_env_name[i];
+    char *value = getenv(name);
+    if (value && *value)
+        setenv_str (es, name, value);
+  }
+}
+
+#endif // ANDROID

--- a/android.h
+++ b/android.h
@@ -1,0 +1,8 @@
+#ifdef ANDROID
+#ifndef OPENVPN_ANDROID_H
+#define OPENVPN_ANDROID_H
+
+void env_set_add_android (struct env_set *);
+
+#endif // OPENVPN_ANDROID_H
+#endif // ANDROID

--- a/crypto.h
+++ b/crypto.h
@@ -37,8 +37,6 @@
 #define CRYPTO_ENGINE 0
 #endif
 
-#define CRYPTO_ENGINE 0
-
 #include <openssl/objects.h>
 #include <openssl/rand.h>
 #include <openssl/evp.h>

--- a/crypto.h
+++ b/crypto.h
@@ -37,6 +37,8 @@
 #define CRYPTO_ENGINE 0
 #endif
 
+#define CRYPTO_ENGINE 0
+
 #include <openssl/objects.h>
 #include <openssl/rand.h>
 #include <openssl/evp.h>

--- a/openvpn.c
+++ b/openvpn.c
@@ -28,6 +28,7 @@
 #include "forward.h"
 #include "multi.h"
 #include "win32.h"
+#include "android.h"
 
 #include "memdbg.h"
 
@@ -134,6 +135,10 @@ main (int argc, char *argv[])
 	  c.es = env_set_create (NULL);
 #ifdef WIN32
 	  env_set_add_win32 (c.es);
+#endif
+
+#ifdef ANDROID
+	  env_set_add_android (c.es);
 #endif
 
 #ifdef ENABLE_MANAGEMENT


### PR DESCRIPTION
Preserve some Android-specific environment variables like
ANDROID_PROPERTY_WORKSPACE so Android tools like getprop will work in
up/down scripts.
